### PR TITLE
Add temp background to graphs

### DIFF
--- a/activity-heatmap.svg
+++ b/activity-heatmap.svg
@@ -1,12 +1,16 @@
 <svg width="166" height="394" xmlns="http://www.w3.org/2000/svg">
   <style>
-    .day-label { font-family: Arial, sans-serif; font-size: 10px; fill: #666; text-anchor: end; }
-    .hour-label { font-family: Arial, sans-serif; font-size: 8px; fill: #666; text-anchor: middle; }
-    .cell { stroke: #fff; stroke-width: 0.5; }
+    .day-label { font-family: Arial, sans-serif; font-size: 10px; fill: #ffffff; text-anchor: end; }
+    .hour-label { font-family: Arial, sans-serif; font-size: 8px; fill: #ffffff; text-anchor: middle; }
+    .cell { stroke: #333; stroke-width: 0.5; }
+    .card-bg { fill: #2a2a2a; stroke: #444; stroke-width: 1; }
   </style>
   
-  <!-- 背景 -->
-  <rect width="166" height="394" fill="#f8f9fa"/>
+  <!-- ダークテーマ背景 -->
+  <rect width="166" height="394" fill="#1a1a1a"/>
+  
+  <!-- カード背景 -->
+  <rect x="10" y="10" width="146" height="374" rx="8" class="card-bg"/>
   <rect x="50" y="40" width="12" height="12" 
            fill="#f5f5f5" class="cell"/>
   <rect x="50" y="54" width="12" height="12" 

--- a/generate-heatmap.js
+++ b/generate-heatmap.js
@@ -35,13 +35,17 @@ const getActivityColor = (level) => {
 // SVG生成
 let svg = `<svg width="${svgWidth}" height="${svgHeight}" xmlns="http://www.w3.org/2000/svg">
   <style>
-    .day-label { font-family: Arial, sans-serif; font-size: 10px; fill: #666; text-anchor: end; }
-    .hour-label { font-family: Arial, sans-serif; font-size: 8px; fill: #666; text-anchor: middle; }
-    .cell { stroke: #fff; stroke-width: 0.5; }
+    .day-label { font-family: Arial, sans-serif; font-size: 10px; fill: #ffffff; text-anchor: end; }
+    .hour-label { font-family: Arial, sans-serif; font-size: 8px; fill: #ffffff; text-anchor: middle; }
+    .cell { stroke: #333; stroke-width: 0.5; }
+    .card-bg { fill: #2a2a2a; stroke: #444; stroke-width: 1; }
   </style>
   
-  <!-- 背景 -->
-  <rect width="${svgWidth}" height="${svgHeight}" fill="#f8f9fa"/>
+  <!-- ダークテーマ背景 -->
+  <rect width="${svgWidth}" height="${svgHeight}" fill="#1a1a1a"/>
+  
+  <!-- カード背景 -->
+  <rect x="10" y="10" width="${svgWidth - 20}" height="${svgHeight - 20}" rx="8" class="card-bg"/>
 `;
 
 

--- a/generate-tech-stack.js
+++ b/generate-tech-stack.js
@@ -36,14 +36,18 @@ const svgHeight = sortedTechs.length * rowHeight + padding * 2;
 // SVG生成
 let svg = `<svg width="${svgWidth}" height="${svgHeight}" xmlns="http://www.w3.org/2000/svg">
   <style>
-    .tech-label { font-family: Arial, sans-serif; font-size: 12px; fill: #333; text-anchor: start; }
-    .percentage-label { font-family: Arial, sans-serif; font-size: 12px; fill: #666; text-anchor: end; }
-    .bar-bg { fill: #e0e0e0; stroke: #ccc; stroke-width: 0.5; }
-    .bar-fill { stroke: #fff; stroke-width: 0.5; }
+    .tech-label { font-family: Arial, sans-serif; font-size: 12px; fill: #ffffff; text-anchor: start; }
+    .percentage-label { font-family: Arial, sans-serif; font-size: 12px; fill: #cccccc; text-anchor: end; }
+    .bar-bg { fill: #333333; stroke: #555; stroke-width: 0.5; }
+    .bar-fill { stroke: #666; stroke-width: 0.5; }
+    .card-bg { fill: #2a2a2a; stroke: #444; stroke-width: 1; }
   </style>
   
-  <!-- 背景 -->
-  <rect width="${svgWidth}" height="${svgHeight}" fill="#f8f9fa"/>
+  <!-- ダークテーマ背景 -->
+  <rect width="${svgWidth}" height="${svgHeight}" fill="#1a1a1a"/>
+  
+  <!-- カード背景 -->
+  <rect x="10" y="10" width="${svgWidth - 20}" height="${svgHeight - 20}" rx="8" class="card-bg"/>
   
 `;
 
@@ -59,6 +63,12 @@ sortedTechs.forEach(([techName, percentage], index) => {
   
   // 技術バー
   svg += `  <rect x="${barX}" y="${y}" width="${fillWidth}" height="${barHeight}" fill="${color}" class="bar-fill"/>\n`;
+  
+  // 技術名ラベル
+  svg += `  <text x="${barX + 5}" y="${y + barHeight/2 + 4}" class="tech-label">${techName}</text>\n`;
+  
+  // パーセンテージラベル
+  svg += `  <text x="${barX + barWidth - 5}" y="${y + barHeight/2 + 4}" class="percentage-label">${percentage}%</text>\n`;
   
 });
 

--- a/tech-stack.svg
+++ b/tech-stack.svg
@@ -1,28 +1,48 @@
 <svg width="440" height="240" xmlns="http://www.w3.org/2000/svg">
   <style>
-    .tech-label { font-family: Arial, sans-serif; font-size: 12px; fill: #333; text-anchor: start; }
-    .percentage-label { font-family: Arial, sans-serif; font-size: 12px; fill: #666; text-anchor: end; }
-    .bar-bg { fill: #e0e0e0; stroke: #ccc; stroke-width: 0.5; }
-    .bar-fill { stroke: #fff; stroke-width: 0.5; }
+    .tech-label { font-family: Arial, sans-serif; font-size: 12px; fill: #ffffff; text-anchor: start; }
+    .percentage-label { font-family: Arial, sans-serif; font-size: 12px; fill: #cccccc; text-anchor: end; }
+    .bar-bg { fill: #333333; stroke: #555; stroke-width: 0.5; }
+    .bar-fill { stroke: #666; stroke-width: 0.5; }
+    .card-bg { fill: #2a2a2a; stroke: #444; stroke-width: 1; }
   </style>
   
-  <!-- 背景 -->
-  <rect width="440" height="240" fill="#f8f9fa"/>
+  <!-- ダークテーマ背景 -->
+  <rect width="440" height="240" fill="#1a1a1a"/>
+  
+  <!-- カード背景 -->
+  <rect x="10" y="10" width="420" height="220" rx="8" class="card-bg"/>
   
   <rect x="20" y="20" width="400" height="20" class="bar-bg"/>
   <rect x="20" y="20" width="340" height="20" fill="#F7DF1E" class="bar-fill"/>
+  <text x="25" y="34" class="tech-label">JavaScript</text>
+  <text x="415" y="34" class="percentage-label">85%</text>
   <rect x="20" y="45" width="400" height="20" class="bar-bg"/>
   <rect x="20" y="45" width="280" height="20" fill="#3776AB" class="bar-fill"/>
+  <text x="25" y="59" class="tech-label">Python</text>
+  <text x="415" y="59" class="percentage-label">70%</text>
   <rect x="20" y="70" width="400" height="20" class="bar-bg"/>
   <rect x="20" y="70" width="240" height="20" fill="#3178C6" class="bar-fill"/>
+  <text x="25" y="84" class="tech-label">TypeScript</text>
+  <text x="415" y="84" class="percentage-label">60%</text>
   <rect x="20" y="95" width="400" height="20" class="bar-bg"/>
   <rect x="20" y="95" width="200" height="20" fill="#61DAFB" class="bar-fill"/>
+  <text x="25" y="109" class="tech-label">React</text>
+  <text x="415" y="109" class="percentage-label">50%</text>
   <rect x="20" y="120" width="400" height="20" class="bar-bg"/>
   <rect x="20" y="120" width="160" height="20" fill="#339933" class="bar-fill"/>
+  <text x="25" y="134" class="tech-label">Node.js</text>
+  <text x="415" y="134" class="percentage-label">40%</text>
   <rect x="20" y="145" width="400" height="20" class="bar-bg"/>
   <rect x="20" y="145" width="120" height="20" fill="#2496ED" class="bar-fill"/>
+  <text x="25" y="159" class="tech-label">Docker</text>
+  <text x="415" y="159" class="percentage-label">30%</text>
   <rect x="20" y="170" width="400" height="20" class="bar-bg"/>
   <rect x="20" y="170" width="100" height="20" fill="#F05032" class="bar-fill"/>
+  <text x="25" y="184" class="tech-label">Git</text>
+  <text x="415" y="184" class="percentage-label">25%</text>
   <rect x="20" y="195" width="400" height="20" class="bar-bg"/>
   <rect x="20" y="195" width="80" height="20" fill="#FF9900" class="bar-fill"/>
+  <text x="25" y="209" class="tech-label">AWS</text>
+  <text x="415" y="209" class="percentage-label">20%</text>
 </svg>


### PR DESCRIPTION
Add a dark theme background and card styling to the heatmap and tech stack graphs to match the provided template image.

---
<a href="https://cursor.com/background-agent?bcId=bc-e2dfceea-6edb-4de5-8c8b-b97669d674ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e2dfceea-6edb-4de5-8c8b-b97669d674ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

